### PR TITLE
Update continuous-integration-workflow.yml

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -3,7 +3,7 @@ on:
   push:
   pull_request:
     types:
-      - created
+      - opened
   schedule:
     - cron: '15 1 * * 1'
 jobs:


### PR DESCRIPTION
"Note: By default, a workflow only runs when a pull_request's activity type is opened, synchronize, or reopened. To trigger workflows for more activity types, use the types keyword." according to https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request